### PR TITLE
Add stablecoin audit platform scaffold

### DIFF
--- a/stablecoin-audit/.github/workflows/ci.yml
+++ b/stablecoin-audit/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+
+on:
+  push:
+    branches: [ main, work ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - run: go mod tidy
+      - run: go test ./...
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m compileall services/algo-worker

--- a/stablecoin-audit/.gitignore
+++ b/stablecoin-audit/.gitignore
@@ -1,0 +1,14 @@
+# Go build artifacts
+bin/
+*.test
+
+# Python virtualenv
+.venv/
+__pycache__/
+
+# Node modules (future front-end)
+node_modules/
+
+# IDE metadata
+.vscode/
+.idea/

--- a/stablecoin-audit/Makefile
+++ b/stablecoin-audit/Makefile
@@ -1,0 +1,16 @@
+.PHONY: tidy test lint proto docker-build
+
+tidy:
+go mod tidy
+
+lint:
+@echo "golangci-lint and mypy hooks can be added here"
+
+test:
+go test ./...
+
+proto:
+@echo "Run protoc to generate Go/Python stubs"
+
+docker-build:
+docker build -t stablecoin-audit/rule-engine -f services/rule-engine/Dockerfile .

--- a/stablecoin-audit/README.md
+++ b/stablecoin-audit/README.md
@@ -1,0 +1,59 @@
+# Stablecoin Audit Platform
+
+This repository implements the core scaffolding for a blockchain stablecoin security audit platform.  It follows the architecture described in the design brief and provides:
+
+- Service skeletons for indexer, rule engine, contract auditor, reserve reconciler, oracle monitor, bridge watcher, compliance API, report builder, and API gateway.
+- Shared Go packages for configuration, logging, Kafka envelope contracts, metrics interfaces, and HTTP server helpers.
+- A Python anomaly detection worker example implementing a depeg index.
+- Database migration files for PostgreSQL and ClickHouse.
+- A configurable YAML-based rules DSL and loader implementation.
+- Proto definitions for the public gRPC interface.
+- Containerization and local development assets (Dockerfile, docker-compose).
+
+The code is intentionally lightweight while capturing the major integration points so individual services can be fleshed out iteratively.
+
+## Project Layout
+
+```
+services/            # Go microservices
+pkg/                 # Shared Go utilities
+proto/               # Protobuf contracts
+migrations/          # Database schema migrations
+rule-dsl/            # Rule DSL definitions and examples
+services/algo-worker # Python analytics workers
+web/                 # Front-end (placeholder)
+deployments/         # Kubernetes/compose manifests
+scripts/             # Developer tooling hooks
+```
+
+## Getting Started
+
+1. Install Go 1.21+ and Python 3.11+.
+2. Run `go mod tidy` to download dependencies.
+3. Use `make up-dev` (to be implemented) or `docker compose -f deployments/docker-compose.yml up` to launch infrastructure.
+4. Run individual services locally with the necessary environment variables, e.g.
+
+```bash
+export DB_URL_PG=postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+export DB_URL_CH=tcp://localhost:9000
+export KAFKA_BROKERS=localhost:9092
+export REDIS_URL=redis://localhost:6379
+export MINIO_ENDPOINT=localhost:9001
+export MINIO_ACCESS_KEY=minio
+export MINIO_SECRET_KEY=minio123
+export ENVIRONMENT=dev
+
+go run ./services/rule-engine
+```
+
+## Testing
+
+- Go unit tests can be added to each service to validate business logic (e.g., rule parsing, reconciliation math).
+- Python analytics modules can be validated with `pytest` or `unittest`.
+
+## Next Steps
+
+- Implement actual blockchain integrations for the indexer and contract auditor.
+- Hook rule engine outputs to Kafka and persistent alert stores.
+- Expand metrics providers and analytics algorithms.
+- Build the React front-end and CI/CD workflows.

--- a/stablecoin-audit/deployments/docker-compose.yml
+++ b/stablecoin-audit/deployments/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+  clickhouse:
+    image: clickhouse/clickhouse-server:23
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  kafka:
+    image: bitnami/kafka:3
+    environment:
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+  zookeeper:
+    image: bitnami/zookeeper:3.8
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+  minio:
+    image: minio/minio:RELEASE.2024-03-15T23-56-19Z
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    ports:
+      - "9001:9000"
+
+  rule-engine:
+    build:
+      context: ..
+      dockerfile: services/rule-engine/Dockerfile
+    environment:
+      DB_URL_PG: postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+      DB_URL_CH: tcp://clickhouse:9000
+      KAFKA_BROKERS: kafka:9092
+      REDIS_URL: redis://redis:6379
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    depends_on:
+      - postgres
+      - clickhouse
+      - kafka
+      - redis
+      - minio

--- a/stablecoin-audit/go.mod
+++ b/stablecoin-audit/go.mod
@@ -1,0 +1,3 @@
+module stablecoin-audit
+
+go 1.21

--- a/stablecoin-audit/migrations/clickhouse/001_events.sql
+++ b/stablecoin-audit/migrations/clickhouse/001_events.sql
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7428ae07cd148988db9e3fa0cfa829d7af889f176f58a5f96760f28039b3649a
+size 360

--- a/stablecoin-audit/migrations/postgres/001_init.sql
+++ b/stablecoin-audit/migrations/postgres/001_init.sql
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d5cfea1d9b7548904ee82df3adab1de9d2fe00ecb4afd36a290196e4ed48e2
+size 1747

--- a/stablecoin-audit/pkg/config/config.go
+++ b/stablecoin-audit/pkg/config/config.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ServiceConfig captures shared infrastructure configuration that is reused across services.
+type ServiceConfig struct {
+	PostgresURL    string
+	ClickHouseURL  string
+	RedisURL       string
+	KafkaBrokers   []string
+	MinIOEndpoint  string
+	MinIOAccessKey string
+	MinIOSecretKey string
+	Environment    string
+}
+
+// LoadFromEnv hydrates ServiceConfig from environment variables with basic validation.
+func LoadFromEnv() (ServiceConfig, error) {
+	cfg := ServiceConfig{
+		PostgresURL:    os.Getenv("DB_URL_PG"),
+		ClickHouseURL:  os.Getenv("DB_URL_CH"),
+		RedisURL:       os.Getenv("REDIS_URL"),
+		KafkaBrokers:   splitAndTrim(os.Getenv("KAFKA_BROKERS")),
+		MinIOEndpoint:  os.Getenv("MINIO_ENDPOINT"),
+		MinIOAccessKey: os.Getenv("MINIO_ACCESS_KEY"),
+		MinIOSecretKey: os.Getenv("MINIO_SECRET_KEY"),
+		Environment:    defaultString(os.Getenv("ENVIRONMENT"), "dev"),
+	}
+
+	if cfg.PostgresURL == "" {
+		return cfg, fmt.Errorf("DB_URL_PG must be provided")
+	}
+	if cfg.ClickHouseURL == "" {
+		return cfg, fmt.Errorf("DB_URL_CH must be provided")
+	}
+	if len(cfg.KafkaBrokers) == 0 {
+		return cfg, fmt.Errorf("KAFKA_BROKERS must contain at least one broker")
+	}
+	return cfg, nil
+}
+
+// Helper used by services that expose port configuration.
+func ReadPortEnv(key string, fallback int) (int, error) {
+	val := strings.TrimSpace(os.Getenv(key))
+	if val == "" {
+		return fallback, nil
+	}
+	port, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port for %s: %w", key, err)
+	}
+	return port, nil
+}
+
+func splitAndTrim(in string) []string {
+	if in == "" {
+		return nil
+	}
+	parts := strings.Split(in, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func defaultString(in, fallback string) string {
+	if strings.TrimSpace(in) == "" {
+		return fallback
+	}
+	return in
+}

--- a/stablecoin-audit/pkg/db/clickhouse.go
+++ b/stablecoin-audit/pkg/db/clickhouse.go
@@ -1,0 +1,8 @@
+package db
+
+import "context"
+
+// ClickHouseConnector is a thin interface that allows substituting real connections in tests.
+type ClickHouseConnector interface {
+	Exec(ctx context.Context, query string, args ...any) error
+}

--- a/stablecoin-audit/pkg/db/postgres.go
+++ b/stablecoin-audit/pkg/db/postgres.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// NewPostgres opens a postgres connection with sane defaults for pooling.
+// The actual driver registration should be performed by the caller.
+func NewPostgres(ctx context.Context, dsn string) (*sql.DB, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	if err := db.PingContext(ctx); err != nil {
+		return nil, err
+	}
+	return db, nil
+}

--- a/stablecoin-audit/pkg/http/server.go
+++ b/stablecoin-audit/pkg/http/server.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Server wraps a net/http server with graceful shutdown semantics.
+type Server struct {
+	Server *http.Server
+}
+
+// New creates an HTTP server with timeout defaults.
+func New(addr string, handler http.Handler) Server {
+	return Server{Server: &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+	}}
+}
+
+// Run starts listening until the context is cancelled.
+func (s Server) Run(ctx context.Context) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Server.ListenAndServe()
+	}()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.Server.Shutdown(shutdownCtx)
+		return ctx.Err()
+	case err := <-done:
+		return err
+	}
+}

--- a/stablecoin-audit/pkg/kafka/envelope.go
+++ b/stablecoin-audit/pkg/kafka/envelope.go
@@ -1,0 +1,25 @@
+package kafka
+
+import "time"
+
+// EventEnvelope mirrors the shared Kafka contract used across services.
+type EventEnvelope struct {
+	EventID   string      `json:"event_id"`
+	Timestamp time.Time   `json:"ts"`
+	Source    string      `json:"source"`
+	ProjectID uint64      `json:"project_id"`
+	Type      string      `json:"type"`
+	Payload   interface{} `json:"payload"`
+}
+
+// NewEnvelope builds a new envelope with the supplied metadata.
+func NewEnvelope(source, typ string, projectID uint64, payload interface{}) EventEnvelope {
+	return EventEnvelope{
+		EventID:   generateUUID(),
+		Timestamp: time.Now().UTC(),
+		Source:    source,
+		ProjectID: projectID,
+		Type:      typ,
+		Payload:   payload,
+	}
+}

--- a/stablecoin-audit/pkg/kafka/uuid.go
+++ b/stablecoin-audit/pkg/kafka/uuid.go
@@ -1,0 +1,18 @@
+package kafka
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+func generateUUID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return ""
+	}
+	// RFC 4122 variant 4 UUID formatting.
+	buf[6] = (buf[6] & 0x0f) | 0x40
+	buf[8] = (buf[8] & 0x3f) | 0x80
+	hexStr := hex.EncodeToString(buf)
+	return hexStr[0:8] + "-" + hexStr[8:12] + "-" + hexStr[12:16] + "-" + hexStr[16:20] + "-" + hexStr[20:32]
+}

--- a/stablecoin-audit/pkg/logging/logger.go
+++ b/stablecoin-audit/pkg/logging/logger.go
@@ -1,0 +1,22 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// NewLogger configures a structured slog Logger with level selection via LOG_LEVEL env.
+func NewLogger() *slog.Logger {
+	level := new(slog.LevelVar)
+	switch os.Getenv("LOG_LEVEL") {
+	case "debug":
+		level.Set(slog.LevelDebug)
+	case "warn":
+		level.Set(slog.LevelWarn)
+	case "error":
+		level.Set(slog.LevelError)
+	default:
+		level.Set(slog.LevelInfo)
+	}
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+}

--- a/stablecoin-audit/pkg/metrics/noop.go
+++ b/stablecoin-audit/pkg/metrics/noop.go
@@ -1,0 +1,10 @@
+package metrics
+
+import "time"
+
+// NoopProvider returns zeroed samples and is useful in scaffolding.
+type NoopProvider struct{}
+
+func (NoopProvider) Fetch(projectID uint64, metric string, window time.Duration) (Sample, error) {
+	return Sample{Name: metric, ProjectID: projectID, Window: window}, nil
+}

--- a/stablecoin-audit/pkg/metrics/provider.go
+++ b/stablecoin-audit/pkg/metrics/provider.go
@@ -1,0 +1,17 @@
+package metrics
+
+import "time"
+
+// Sample represents a metric datapoint consumed by the rule engine.
+type Sample struct {
+	Name      string
+	ProjectID uint64
+	Value     float64
+	Window    time.Duration
+	Timestamp time.Time
+}
+
+// Provider describes how rule-engine obtains metric samples.
+type Provider interface {
+	Fetch(projectID uint64, metric string, window time.Duration) (Sample, error)
+}

--- a/stablecoin-audit/pkg/rules/loader.go
+++ b/stablecoin-audit/pkg/rules/loader.go
@@ -1,0 +1,298 @@
+package rules
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Loader reads YAML rule definitions and produces typed Rule structures.
+type Loader struct {
+	root string
+}
+
+func NewLoader(root string) Loader {
+	return Loader{root: root}
+}
+
+func (l Loader) Load() ([]Rule, error) {
+	var rules []Rule
+	err := filepath.WalkDir(l.root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			return nil
+		}
+		rule, err := l.loadFile(path)
+		if err != nil {
+			return fmt.Errorf("load rule %s: %w", path, err)
+		}
+		rules = append(rules, rule)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rules, nil
+}
+
+func (l Loader) loadFile(path string) (Rule, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Rule{}, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	rule := Rule{}
+	var section string
+	var currentClause *Clause
+	var currentEvidence *Evidence
+	var currentAction *Action
+
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		rawLine := scanner.Text()
+		trimmed := strings.TrimSpace(rawLine)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		indent := countIndent(rawLine)
+
+		if indent == 0 {
+			key, value, err := splitKV(trimmed)
+			if err != nil {
+				return Rule{}, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+			}
+			if value == nil {
+				section = key
+				continue
+			}
+			switch key {
+			case "id":
+				rule.ID = value.str
+			case "name":
+				rule.Name = value.str
+			case "severity":
+				rule.Severity = value.str
+			case "scope":
+				rule.Scope = value.str
+			default:
+				return Rule{}, fmt.Errorf("%s:%d: unknown key %s", path, lineNo, key)
+			}
+			continue
+		}
+
+		switch section {
+		case "when":
+			if strings.HasPrefix(trimmed, "- ") {
+				rule.Clauses = append(rule.Clauses, Clause{})
+				currentClause = &rule.Clauses[len(rule.Clauses)-1]
+				trimmed = strings.TrimPrefix(trimmed, "- ")
+				if trimmed != "" {
+					if err := assignClauseField(currentClause, trimmed); err != nil {
+						return Rule{}, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+					}
+				}
+				continue
+			}
+			if currentClause == nil {
+				return Rule{}, fmt.Errorf("%s:%d: clause attribute without entry", path, lineNo)
+			}
+			if err := assignClauseField(currentClause, trimmed); err != nil {
+				return Rule{}, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+			}
+		case "evidence":
+			if strings.HasPrefix(trimmed, "- ") {
+				rule.Evidence = append(rule.Evidence, Evidence{})
+				currentEvidence = &rule.Evidence[len(rule.Evidence)-1]
+				trimmed = strings.TrimPrefix(trimmed, "- ")
+				if trimmed != "" {
+					if err := assignEvidenceField(currentEvidence, trimmed); err != nil {
+						return Rule{}, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+					}
+				}
+				continue
+			}
+			if currentEvidence == nil {
+				return Rule{}, fmt.Errorf("%s:%d: evidence attribute without entry", path, lineNo)
+			}
+			if err := assignEvidenceField(currentEvidence, trimmed); err != nil {
+				return Rule{}, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+			}
+		case "action":
+			if strings.HasPrefix(trimmed, "- ") {
+				rule.Actions = append(rule.Actions, Action{})
+				currentAction = &rule.Actions[len(rule.Actions)-1]
+				trimmed = strings.TrimPrefix(trimmed, "- ")
+				if trimmed != "" {
+					if err := assignActionField(currentAction, trimmed); err != nil {
+						return Rule{}, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+					}
+				}
+				continue
+			}
+			if currentAction == nil {
+				return Rule{}, fmt.Errorf("%s:%d: action attribute without entry", path, lineNo)
+			}
+			if err := assignActionField(currentAction, trimmed); err != nil {
+				return Rule{}, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+			}
+		default:
+			return Rule{}, fmt.Errorf("%s:%d: unexpected section %s", path, lineNo, section)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Rule{}, err
+	}
+	if rule.ID == "" {
+		return Rule{}, errors.New("rule missing id")
+	}
+	return rule, nil
+}
+
+type valueHolder struct {
+	str   string
+	float *float64
+	bool  *bool
+}
+
+func splitKV(line string) (string, *valueHolder, error) {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) != 2 {
+		return "", nil, fmt.Errorf("invalid key-value: %s", line)
+	}
+	key := strings.TrimSpace(parts[0])
+	value := strings.TrimSpace(parts[1])
+	if value == "" {
+		return key, nil, nil
+	}
+	holder := valueHolder{str: trimQuotes(value)}
+	if f, err := strconv.ParseFloat(holder.str, 64); err == nil {
+		holder.float = &f
+	}
+	if b, err := strconv.ParseBool(strings.ToLower(holder.str)); err == nil {
+		holder.bool = &b
+	}
+	return key, &holder, nil
+}
+
+func assignClauseField(clause *Clause, line string) error {
+	key, val, err := splitKV(line)
+	if err != nil {
+		return err
+	}
+	if val == nil {
+		return fmt.Errorf("missing value for %s", key)
+	}
+	switch key {
+	case "metric":
+		clause.Metric = val.str
+	case "op":
+		clause.Op = val.str
+	case "value":
+		if val.float == nil {
+			return fmt.Errorf("value must be float")
+		}
+		clause.Value = *val.float
+	case "window":
+		d, err := time.ParseDuration(val.str)
+		if err != nil {
+			return err
+		}
+		clause.Window = d
+	default:
+		return fmt.Errorf("unknown clause key %s", key)
+	}
+	return nil
+}
+
+func assignEvidenceField(ev *Evidence, line string) error {
+	key, val, err := splitKV(line)
+	if err != nil {
+		return err
+	}
+	if val == nil {
+		return fmt.Errorf("missing value for %s", key)
+	}
+	switch key {
+	case "type":
+		ev.Type = val.str
+	case "ref":
+		ev.Ref = val.str
+	default:
+		return fmt.Errorf("unknown evidence key %s", key)
+	}
+	return nil
+}
+
+func assignActionField(action *Action, line string) error {
+	key, val, err := splitKV(line)
+	if err != nil {
+		return err
+	}
+	if val == nil {
+		return fmt.Errorf("missing value for %s", key)
+	}
+	switch key {
+	case "emit_alert":
+		if val.bool == nil {
+			return fmt.Errorf("emit_alert must be boolean")
+		}
+		action.EmitAlert = *val.bool
+	case "tags":
+		action.Tags = parseList(val.str)
+	default:
+		return fmt.Errorf("unknown action key %s", key)
+	}
+	return nil
+}
+
+func trimQuotes(in string) string {
+	in = strings.TrimSpace(in)
+	if strings.HasPrefix(in, "\"") && strings.HasSuffix(in, "\"") {
+		return strings.Trim(in, "\"")
+	}
+	if strings.HasPrefix(in, "[") && strings.HasSuffix(in, "]") {
+		return in
+	}
+	if strings.HasPrefix(in, "'") && strings.HasSuffix(in, "'") {
+		return strings.Trim(in, "'")
+	}
+	return in
+}
+
+func parseList(value string) []string {
+	trimmed := strings.TrimSpace(value)
+	trimmed = strings.TrimPrefix(trimmed, "[")
+	trimmed = strings.TrimSuffix(trimmed, "]")
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		result = append(result, strings.TrimSpace(strings.Trim(p, "\"'")))
+	}
+	return result
+}
+
+func countIndent(line string) int {
+	count := 0
+	for _, r := range line {
+		if r == ' ' {
+			count++
+		} else {
+			break
+		}
+	}
+	return count
+}

--- a/stablecoin-audit/pkg/rules/model.go
+++ b/stablecoin-audit/pkg/rules/model.go
@@ -1,0 +1,34 @@
+package rules
+
+import "time"
+
+// Rule describes a compiled DSL rule that the engine can evaluate.
+type Rule struct {
+	ID       string
+	Name     string
+	Severity string
+	Scope    string
+	Clauses  []Clause
+	Evidence []Evidence
+	Actions  []Action
+}
+
+// Clause defines a single metric threshold evaluation.
+type Clause struct {
+	Metric string
+	Op     string
+	Value  float64
+	Window time.Duration
+}
+
+// Evidence captures references that should be attached to alerts.
+type Evidence struct {
+	Type string
+	Ref  string
+}
+
+// Action enumerates alert behavior toggles.
+type Action struct {
+	EmitAlert bool
+	Tags      []string
+}

--- a/stablecoin-audit/proto/audit.proto
+++ b/stablecoin-audit/proto/audit.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+package audit.v1;
+
+option go_package = "stablecoin-audit/proto/gen/go/audit/v1";
+
+message Project {
+  uint64 id = 1;
+  string name = 2;
+  string symbol = 3;
+  uint32 decimals = 4;
+  map<string, string> chains = 5;
+}
+
+message RegisterProjectRequest {
+  string name = 1;
+  string symbol = 2;
+  uint32 decimals = 3;
+  map<string, string> chains = 4;
+}
+
+message RegisterProjectResponse { Project project = 1; }
+
+message GetBaselineRequest { uint64 project_id = 1; }
+message Finding { string code = 1; string title = 2; string severity = 3; string detail = 4; }
+message BaselineReport {
+  string owner_type = 1;
+  uint32 risk_score = 2;
+  repeated Finding findings = 3;
+}
+message GetBaselineResponse { BaselineReport report = 1; }
+
+service ProjectService {
+  rpc RegisterProject(RegisterProjectRequest) returns (RegisterProjectResponse);
+  rpc GetBaseline(GetBaselineRequest) returns (GetBaselineResponse);
+}

--- a/stablecoin-audit/requirements.txt
+++ b/stablecoin-audit/requirements.txt
@@ -1,0 +1,3 @@
+# Python analytics dependencies placeholder
+numpy
+pandas

--- a/stablecoin-audit/rule-dsl/rules/r-201-supply-diff.yaml
+++ b/stablecoin-audit/rule-dsl/rules/r-201-supply-diff.yaml
@@ -1,0 +1,15 @@
+id: R-201
+name: "跨链供给不一致"
+severity: HIGH
+scope: project
+when:
+  - metric: supply_diff_ratio
+    op: ">"
+    value: 0.02
+    window: "5m"
+evidence:
+  - type: "timeseries"
+    ref: "supply_snapshot.*"
+action:
+  - emit_alert: true
+    tags: ["supply", "crosschain"]

--- a/stablecoin-audit/scripts/dev_setup.sh
+++ b/stablecoin-audit/scripts/dev_setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Placeholder for initializing local environment.
+echo "Setting up local environment..."
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt 2>/dev/null || true

--- a/stablecoin-audit/services/algo-worker/worker.py
+++ b/stablecoin-audit/services/algo-worker/worker.py
@@ -1,0 +1,47 @@
+"""Algo worker entry point for anomaly detection tasks."""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class PriceSample:
+    timestamp: float
+    value: float
+
+
+def ema(values: Iterable[float], span: int) -> List[float]:
+    alpha = 2 / (span + 1)
+    result: List[float] = []
+    prev = None
+    for value in values:
+        if prev is None:
+            prev = value
+        else:
+            prev = alpha * value + (1 - alpha) * prev
+        result.append(prev)
+    return result
+
+
+def depeg_index(samples: Iterable[PriceSample], anchor: float = 1.0) -> float:
+    ratios = [abs(sample.value - anchor) / anchor for sample in samples]
+    if not ratios:
+        return 0.0
+    smooth = ema(ratios, span=20)
+    return smooth[-1]
+
+
+def consume_event(event: str) -> None:
+    payload = json.loads(event)
+    prices = [PriceSample(timestamp=item["ts"], value=item["price"]) for item in payload["prices"]]
+    score = depeg_index(prices)
+    if math.isfinite(score):
+        print(json.dumps({"score": score, "rule_id": "ALG-DEPEG"}))
+
+
+if __name__ == "__main__":
+    example = json.dumps({"prices": [{"ts": 0, "price": 1.0}, {"ts": 60, "price": 0.995}]})
+    consume_event(example)

--- a/stablecoin-audit/services/api-gateway/main.go
+++ b/stablecoin-audit/services/api-gateway/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+
+	gateway := NewServer(cfg, logger)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := gateway.Run(ctx); err != nil {
+		logger.Error("api gateway stopped", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/api-gateway/server.go
+++ b/stablecoin-audit/services/api-gateway/server.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	stdhttp "stablecoin-audit/pkg/http"
+
+	"stablecoin-audit/pkg/config"
+)
+
+type Server struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+	http   stdhttp.Server
+}
+
+func NewServer(cfg config.ServiceConfig, logger *slog.Logger) Server {
+	handler := http.NewServeMux()
+	s := Server{cfg: cfg, logger: logger}
+	handler.HandleFunc("/v1/projects", s.handleProjects)
+	handler.HandleFunc("/v1/projects/", s.handleProjectDetail)
+	handler.HandleFunc("/v1/alerts", s.handleAlerts)
+
+	port, _ := config.ReadPortEnv("API_PORT", 8080)
+	s.http = stdhttp.New(fmt.Sprintf(":%d", port), handler)
+	return s
+}
+
+func (s Server) Run(ctx context.Context) error {
+	s.logger.Info("api gateway listening")
+	return s.http.Run(ctx)
+}
+
+type project struct {
+	ID       uint64            `json:"id"`
+	Name     string            `json:"name"`
+	Symbol   string            `json:"symbol"`
+	Chains   map[string]string `json:"chains"`
+	Decimals uint32            `json:"decimals"`
+}
+
+type alert struct {
+	ID       uint64      `json:"id"`
+	Project  uint64      `json:"project_id"`
+	Severity string      `json:"severity"`
+	Title    string      `json:"title"`
+	Details  interface{} `json:"details"`
+}
+
+func (s Server) handleProjects(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var req project
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		req.ID = 1
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(req)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s Server) handleProjectDetail(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	resp := map[string]any{
+		"baseline": map[string]any{
+			"owner_type": "EOA",
+			"risk_score": 70,
+		},
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s Server) handleAlerts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	items := []alert{
+		{ID: 1, Project: 1, Severity: "HIGH", Title: "Supply mismatch", Details: map[string]any{"delta": 0.03}},
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"items":        items,
+		"generated_at": time.Now().UTC(),
+	})
+}

--- a/stablecoin-audit/services/bridge-watcher/main.go
+++ b/stablecoin-audit/services/bridge-watcher/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+	watcher := NewWatcher(cfg, logger)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := watcher.Run(ctx); err != nil {
+		logger.Error("bridge watcher stopped", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/bridge-watcher/watcher.go
+++ b/stablecoin-audit/services/bridge-watcher/watcher.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+)
+
+// Watcher inspects lock/mint/burn/unlock relations between chains.
+type Watcher struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+}
+
+func NewWatcher(cfg config.ServiceConfig, logger *slog.Logger) *Watcher {
+	return &Watcher{cfg: cfg, logger: logger}
+}
+
+func (w *Watcher) Run(ctx context.Context) error {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			w.logger.Info("bridge diff summary", slog.Int("pending_pairs", len(w.findMismatches())))
+		}
+	}
+}
+
+func (w *Watcher) findMismatches() []string {
+	// TODO: query ClickHouse materialized views and return unmatched flows.
+	return []string{}
+}

--- a/stablecoin-audit/services/compliance/main.go
+++ b/stablecoin-audit/services/compliance/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os/signal"
+	"syscall"
+
+	stdhttp "stablecoin-audit/pkg/http"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+
+	svc := NewService(cfg, logger)
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/compliance/score", svc.handleScore)
+
+	port, err := config.ReadPortEnv("HTTP_PORT", 8085)
+	if err != nil {
+		logger.Error("invalid port", slog.Any("err", err))
+		return
+	}
+	server := stdhttp.New(fmt.Sprintf(":%d", port), handler)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := server.Run(ctx); err != nil {
+		logger.Error("compliance server stopped", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/compliance/service.go
+++ b/stablecoin-audit/services/compliance/service.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+)
+
+// Service integrates with external KYT providers and caches results.
+type Service struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+}
+
+func NewService(cfg config.ServiceConfig, logger *slog.Logger) Service {
+	return Service{cfg: cfg, logger: logger}
+}
+
+type scoreRequest struct {
+	Address string `json:"address"`
+}
+
+type scoreResponse struct {
+	Address string  `json:"address"`
+	Risk    float64 `json:"risk"`
+	TTL     int     `json:"ttl_seconds"`
+}
+
+func (s Service) handleScore(w http.ResponseWriter, r *http.Request) {
+	var req scoreRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	risk := s.scoreAddress(req.Address)
+	resp := scoreResponse{Address: req.Address, Risk: risk, TTL: int((5 * time.Minute).Seconds())}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s Service) scoreAddress(address string) float64 {
+	if address == "" {
+		return 1.0
+	}
+	// TODO: call out to KYT provider and aggregate results.
+	return 0.1
+}

--- a/stablecoin-audit/services/contract-auditor/auditor.go
+++ b/stablecoin-audit/services/contract-auditor/auditor.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+)
+
+// Auditor coordinates smart contract scanning jobs.
+type Auditor struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+}
+
+func NewAuditor(cfg config.ServiceConfig, logger *slog.Logger) *Auditor {
+	return &Auditor{cfg: cfg, logger: logger}
+}
+
+func (a *Auditor) Run(ctx context.Context) error {
+	a.logger.Info("contract auditor online")
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			a.logger.Info("shutdown signal received")
+			return ctx.Err()
+		case <-ticker.C:
+			a.logger.Debug("scheduled baseline scan tick")
+		}
+	}
+}
+
+// ScanBaseline contains the scoring blueprint from the design document.
+type ScanBaselineResult struct {
+	OwnerType      string
+	RiskScore      uint32
+	Findings       []Finding
+	TokenAddress   string
+	Implementation string
+	ProxyAddress   string
+}
+
+type Finding struct {
+	Code     string
+	Title    string
+	Severity string
+	Detail   string
+}
+
+func (a *Auditor) ScanBaseline(ctx context.Context, tokenAddress string) (ScanBaselineResult, error) {
+	// TODO: integrate with on-chain RPC and ABI inspection
+	result := ScanBaselineResult{OwnerType: "EOA", TokenAddress: tokenAddress, RiskScore: 40}
+	result.Findings = append(result.Findings, Finding{
+		Code:     "OWNER_EOA",
+		Title:    "Owner is externally owned account",
+		Severity: "HIGH",
+		Detail:   "Single key risk detected, consider multisig or timelock",
+	})
+	return result, nil
+}

--- a/stablecoin-audit/services/contract-auditor/main.go
+++ b/stablecoin-audit/services/contract-auditor/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+	auditor := NewAuditor(cfg, logger)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	if err := auditor.Run(ctx); err != nil {
+		logger.Error("auditor exited", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/indexer/indexer.go
+++ b/stablecoin-audit/services/indexer/indexer.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+)
+
+// Indexer wires together block subscriptions, decoding and sinks.
+type Indexer struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+}
+
+func NewIndexer(cfg config.ServiceConfig, logger *slog.Logger) *Indexer {
+	return &Indexer{cfg: cfg, logger: logger}
+}
+
+func (i *Indexer) Run(ctx context.Context) error {
+	i.logger.Info("starting indexer", slog.Any("brokers", i.cfg.KafkaBrokers))
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			i.logger.Info("context cancelled, shutting down")
+			return ctx.Err()
+		case <-ticker.C:
+			i.logger.Debug("heartbeat", slog.String("component", "indexer"))
+		}
+	}
+}
+
+// ProcessBlock is intentionally left with pseudo-code to guide implementation.
+func (i *Indexer) ProcessBlock(ctx context.Context, blockNumber uint64) error {
+	if blockNumber == 0 {
+		return errors.New("block number cannot be zero")
+	}
+	// 1. Fetch block via RPC.
+	// 2. Decode transaction logs with registered ABI catalog.
+	// 3. Push events to ClickHouse and Kafka using shared sinks.
+	// 4. Track reorg safety using confirmation depth.
+	return nil
+}

--- a/stablecoin-audit/services/indexer/main.go
+++ b/stablecoin-audit/services/indexer/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("load config", slog.Any("err", err))
+		return
+	}
+
+	indexer := NewIndexer(cfg, logger)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	if err := indexer.Run(ctx); err != nil {
+		logger.Error("indexer exited", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/oracle-monitor/main.go
+++ b/stablecoin-audit/services/oracle-monitor/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+	monitor := NewMonitor(cfg, logger)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := monitor.Run(ctx); err != nil {
+		logger.Error("oracle monitor stopped", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/oracle-monitor/monitor.go
+++ b/stablecoin-audit/services/oracle-monitor/monitor.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+)
+
+// Monitor compares oracle feeds to detect divergence.
+type Monitor struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+}
+
+func NewMonitor(cfg config.ServiceConfig, logger *slog.Logger) *Monitor {
+	return &Monitor{cfg: cfg, logger: logger}
+}
+
+func (m *Monitor) Run(ctx context.Context) error {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			feeds := []float64{1.0, 1.001, 0.999}
+			z := zScore(feeds)
+			m.logger.Debug("oracle zscore", slog.Float64("z", z))
+		}
+	}
+}
+
+func zScore(samples []float64) float64 {
+	n := float64(len(samples))
+	if n == 0 {
+		return 0
+	}
+	mean := 0.0
+	for _, v := range samples {
+		mean += v
+	}
+	mean /= n
+	variance := 0.0
+	for _, v := range samples {
+		variance += math.Pow(v-mean, 2)
+	}
+	if variance == 0 {
+		return 0
+	}
+	stdDev := math.Sqrt(variance / n)
+	return (samples[0] - mean) / stdDev
+}

--- a/stablecoin-audit/services/report-builder/builder.go
+++ b/stablecoin-audit/services/report-builder/builder.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+)
+
+// Builder aggregates findings and templates into final reports.
+type Builder struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+}
+
+func NewBuilder(cfg config.ServiceConfig, logger *slog.Logger) *Builder {
+	return &Builder{cfg: cfg, logger: logger}
+}
+
+func (b *Builder) Run(ctx context.Context) error {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			report := b.BuildReport("example-project")
+			b.logger.Info("report compiled", slog.String("project", report.ProjectName))
+		}
+	}
+}
+
+type Report struct {
+	ProjectName string
+	GeneratedAt time.Time
+	Findings    []string
+}
+
+func (b *Builder) BuildReport(project string) Report {
+	return Report{
+		ProjectName: project,
+		GeneratedAt: time.Now().UTC(),
+		Findings: []string{
+			"Owner is multisig",
+			"Reserve ratio healthy",
+		},
+	}
+}

--- a/stablecoin-audit/services/report-builder/main.go
+++ b/stablecoin-audit/services/report-builder/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+
+	builder := NewBuilder(cfg, logger)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := builder.Run(ctx); err != nil {
+		logger.Error("report builder stopped", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/reserve-reconciler/main.go
+++ b/stablecoin-audit/services/reserve-reconciler/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+	reconciler := NewReconciler(cfg, logger)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := reconciler.Run(ctx); err != nil {
+		logger.Error("reconciler stopped", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/services/reserve-reconciler/reconciler.go
+++ b/stablecoin-audit/services/reserve-reconciler/reconciler.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"math"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+)
+
+// Reconciler merges on-chain supply snapshots with off-chain reserves.
+type Reconciler struct {
+	cfg    config.ServiceConfig
+	logger *slog.Logger
+}
+
+func NewReconciler(cfg config.ServiceConfig, logger *slog.Logger) *Reconciler {
+	return &Reconciler{cfg: cfg, logger: logger}
+}
+
+func (r *Reconciler) Run(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			r.logger.Info("context done")
+			return ctx.Err()
+		case <-ticker.C:
+			if result, err := r.Reconcile(ctx, 0, time.Now()); err != nil {
+				r.logger.Warn("reconcile failed", slog.Any("err", err))
+			} else {
+				r.logger.Info("reconcile complete", slog.Float64("ratio", result.Ratio), slog.Float64("hhi", result.HHI))
+			}
+		}
+	}
+}
+
+type Result struct {
+	Ratio float64
+	HHI   float64
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, projectID uint64, asOf time.Time) (Result, error) {
+	_ = ctx
+	if asOf.IsZero() {
+		return Result{}, errors.New("asOf cannot be zero")
+	}
+	onChain := 1000000.0
+	reserves := []float64{400000, 350000, 250000}
+	ratio := sum(reserves...) / onChain
+	hhi := calcHHI(reserves)
+	return Result{Ratio: ratio, HHI: hhi}, nil
+}
+
+func sum(values ...float64) float64 {
+	total := 0.0
+	for _, v := range values {
+		total += v
+	}
+	return total
+}
+
+func calcHHI(reserves []float64) float64 {
+	total := sum(reserves...)
+	if total == 0 {
+		return 0
+	}
+	acc := 0.0
+	for _, r := range reserves {
+		s := r / total
+		acc += math.Pow(s, 2)
+	}
+	return acc
+}

--- a/stablecoin-audit/services/rule-engine/Dockerfile
+++ b/stablecoin-audit/services/rule-engine/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.21 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+RUN CGO_ENABLED=0 go build -o /bin/rule-engine ./services/rule-engine
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=build /bin/rule-engine /bin/rule-engine
+COPY rule-dsl /app/rule-dsl
+ENTRYPOINT ["/bin/rule-engine"]

--- a/stablecoin-audit/services/rule-engine/engine.go
+++ b/stablecoin-audit/services/rule-engine/engine.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/kafka"
+	"stablecoin-audit/pkg/metrics"
+	"stablecoin-audit/pkg/rules"
+)
+
+// Engine evaluates DSL rules by fetching metrics and emitting events.
+type Engine struct {
+	cfg      config.ServiceConfig
+	logger   *slog.Logger
+	ruleSet  []rules.Rule
+	provider metrics.Provider
+}
+
+func NewEngine(cfg config.ServiceConfig, logger *slog.Logger) (*Engine, error) {
+	ruleLoader := rules.NewLoader("rule-dsl/rules")
+	rules, err := ruleLoader.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load rules: %w", err)
+	}
+	return &Engine{cfg: cfg, logger: logger, ruleSet: rules, provider: metrics.NoopProvider{}}, nil
+}
+
+func (e *Engine) Run(ctx context.Context) error {
+	e.logger.Info("rule engine running", slog.Int("rules", len(e.ruleSet)))
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			e.logger.Info("context done")
+			return ctx.Err()
+		case <-ticker.C:
+			for _, rule := range e.ruleSet {
+				if err := e.evaluate(ctx, rule); err != nil {
+					e.logger.Warn("rule evaluation failed", slog.String("rule", rule.ID), slog.Any("err", err))
+				}
+			}
+		}
+	}
+}
+
+func (e *Engine) evaluate(ctx context.Context, rule rules.Rule) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if len(rule.Clauses) == 0 {
+		return errors.New("rule missing clauses")
+	}
+	clause := rule.Clauses[0]
+	sample, err := e.provider.Fetch(0, clause.Metric, clause.Window)
+	if err != nil {
+		return err
+	}
+	if compare(clause.Op, sample.Value, clause.Value) {
+		e.emit(rule, sample)
+	}
+	return nil
+}
+
+func (e *Engine) emit(rule rules.Rule, sample metrics.Sample) {
+	env := kafka.NewEnvelope("rule-engine", "ALERT", sample.ProjectID, map[string]any{
+		"rule_id": rule.ID,
+		"metric":  sample.Name,
+		"value":   sample.Value,
+	})
+	e.logger.Info("alert", slog.Any("envelope", env))
+}
+
+func compare(op string, lhs, rhs float64) bool {
+	switch op {
+	case ">":
+		return lhs > rhs
+	case ">=":
+		return lhs >= rhs
+	case "<":
+		return lhs < rhs
+	case "<=":
+		return lhs <= rhs
+	case "==":
+		return lhs == rhs
+	case "!=":
+		return lhs != rhs
+	default:
+		return false
+	}
+}
+
+// Noop provider lives here to avoid cyclic dependency.
+var _ metrics.Provider = metrics.NoopProvider{}

--- a/stablecoin-audit/services/rule-engine/main.go
+++ b/stablecoin-audit/services/rule-engine/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"stablecoin-audit/pkg/config"
+	"stablecoin-audit/pkg/logging"
+)
+
+func main() {
+	logger := logging.NewLogger()
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		logger.Error("config error", slog.Any("err", err))
+		return
+	}
+
+	re, err := NewEngine(cfg, logger)
+	if err != nil {
+		logger.Error("bootstrap rule engine", slog.Any("err", err))
+		return
+	}
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := re.Run(ctx); err != nil {
+		logger.Error("rule engine stopped", slog.Any("err", err))
+	}
+}

--- a/stablecoin-audit/web/README.md
+++ b/stablecoin-audit/web/README.md
@@ -1,0 +1,8 @@
+# Web Front-End
+
+Placeholder directory for the React/TypeScript operations console. Future iterations should include:
+
+- Project overview dashboards with supply and reserve charts.
+- Alert triage boards with filtering, assignment, and evidence previews.
+- Evidence workbench for replaying blockchain events.
+- Compliance views for address tagging.


### PR DESCRIPTION
## Summary
- scaffold monorepo structure for the stablecoin audit platform with core Go services and shared libraries
- add sample rule DSL file, database migrations, protobuf contracts, and Docker assets
- include Python anomaly detection worker example plus CI, Makefile, and developer tooling placeholders

## Testing
- go test ./...
- python -m compileall services/algo-worker


------
https://chatgpt.com/codex/tasks/task_e_68cd8e85c1ac832d9d1a0bf4a43f2ba2